### PR TITLE
Fix callback default message

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -131,7 +131,7 @@ class JwtAuthentication
             $params = ["decoded" => $decoded];
             if (false === $this->options["callback"]($request, $response, $params)) {
                 return $this->error($request, $response, [
-                    "message" => $this->message || "Callback returned false"
+                    "message" => $this->message ? $this->message : "Callback returned false"
                 ])->withStatus(401);
             }
         }


### PR DESCRIPTION
When "callback", that does not set a message and returns false, expected message is "Callback returned false", but following code returns `true`

``` php
$arguments = [
    "message" => $this->message || "Callback returned false"
]
$arguments["message"] === true
```
