### PR TITLE
Added the ability to find the token from the query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,6 @@ $app->add(new \Slim\Middleware\JwtAuthentication([
 ```
 ### Passthrough by request and method
 
-
-With optional `passthrough` parameter you can make exceptions to `path` parameter. In the example below everything starting with `/api` and `/admin`  will be authenticated with the exception of `/api/token` and `/admin/ping` which will not be authenticated.
-
 ``` php
 $app = new \Slim\App();
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For example implementation see [Slim API Skeleton](https://github.com/tuupola/sl
 Install latest version using [composer](https://getcomposer.org/).
 
 ``` bash
-$ composer require tuupola/slim-jwt-auth
+$ composer require elbanyaoui/slim-jwt-auth
 ```
 
 If using Apache add the following to the `.htaccess` file. Otherwise PHP wont have access to `Authorization: Bearer` header.
@@ -81,6 +81,35 @@ $app->add(new \Slim\Middleware\JwtAuthentication([
     "path" => ["/api", "/admin"],
     "passthrough" => ["/api/token", "/admin/ping"],
     "secret" => "supersecretkeyyoushouldnotcommittogithub"
+]));
+```
+### Passthrough by request and method
+
+
+With optional `passthrough` parameter you can make exceptions to `path` parameter. In the example below everything starting with `/api` and `/admin`  will be authenticated with the exception of `/api/token` and `/admin/ping` which will not be authenticated.
+
+``` php
+$app = new \Slim\App();
+
+$app->add(new \Slim\Middleware\JwtAuthentication([
+    "path" => ["/api", "/admin"],
+    "passthrough" => ["/api/token", "/admin/ping"],
+    "secret" => "supersecretkeyyoushouldnotcommittogithub",
+	"rules" => [
+        new\Slim\Middleware\JwtAuthentication\RequestMethodRule([
+            "passthrough" => ["OPTIONS"]
+        ]),
+        new\Slim\Middleware\JwtAuthentication\RequestMethodPathRule([
+            "passthrough" => [
+                "GET"=>"/items/"
+            ]
+        ]),
+        new\Slim\Middleware\JwtAuthentication\RequestMethodPathRule([
+            "passthrough" => [
+                "GET"=>"/categories/"
+            ]
+        ])
+    ],
 ]));
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "tuupola/slim-jwt-auth",
-    "description": "PSR-7 JWT Authentication Middleware",
+    "name": "elbanyaoui/slim-jwt-auth",
+    "description": "PSR-7 JWT Authentication Middleware a customized version created by elbanyaoui based on tuupola/slim-jwt-auth project",
     "keywords": [
         "psr-7",
         "middleware",
@@ -8,13 +8,13 @@
         "json",
         "auth"
     ],
-    "homepage": "https://github.com/tuupola/slim-jwt-auth",
+    "homepage": "https://github.com/elbanyaoui/slim-jwt-auth",
     "license": "MIT",
     "authors": [
         {
-            "name": "Mika Tuupola",
-            "email": "tuupola@appelsiini.net",
-            "homepage": "http://www.appelsiini.net/",
+            "name": "Moahmmed EL BANYAOUI",
+            "email": "elbanyaoui@hotmail.com",
+            "homepage": "http://www.elbanyaoui.com",
             "role": "Developer"
         }
     ],

--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -46,6 +46,7 @@ class JwtAuthentication
         "header" => "Authorization",
         "regexp" => "/Bearer\s+(.*)$/i",
         "cookie" => "token",
+        "url" => "access_token",
         "attribute" => "token",
         "path" => null,
         "passthrough" => null,
@@ -229,6 +230,14 @@ class JwtAuthentication
             $this->log(LogLevel::DEBUG, "Using token from cookie");
             $this->log(LogLevel::DEBUG, $cookie_params[$this->options["cookie"]]);
             return $cookie_params[$this->options["cookie"]];
+        };
+
+        /* cookie not found, try the query params. */
+        $params = $request->getQueryParams();
+        if (isset($params[$this->options["url"]]) && !empty($params[$this->options["url"]])) {
+            $this->log(LogLevel::DEBUG, "Using token from query params");
+            $this->log(LogLevel::DEBUG, $params[$this->options["url"]]);
+            return $params[$this->options["url"]];
         };
 
         /* If everything fails log and return false. */

--- a/src/JwtAuthentication/RequestMethodPathRule.php
+++ b/src/JwtAuthentication/RequestMethodPathRule.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of PSR-7 JSON Web Token Authentication middleware & created by Mohammed EL b=BANYAOUI
+ *
+ * Copyright (c) 2015-2016 Mika Tuupola
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   https://github.com/tuupola/slim-jwt-auth
+ *
+ */
+namespace Slim\Middleware\JwtAuthentication;
+
+use Psr\Http\Message\RequestInterface;
+
+class RequestMethodPathRule implements RuleInterface
+{
+    /**
+     * Stores all the options passed to the rule
+     */
+    protected $options = [
+        'path' => ['/'],
+        'passthrough' => [
+            'OPTIONS' => '/'
+        ]
+    ];
+    /**
+     * Create a new rule instance
+     *
+     * @param string[] $options
+     * @return void
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge($this->options, $options);
+    }
+    /**
+     * Rules to decide by HTTP verb and request path whether or not the request should be authenticated
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return boolean
+     */
+    public function __invoke(RequestInterface $request)
+    {
+        $uri    = "/" . $request->getUri()->getPath();
+        $uri    = str_replace("//", "/", $uri);
+        $method = $request->getMethod();
+        /* If request method (or lack of) and path matches passthrough we should not authenticate. */
+        foreach ((array) $this->options["passthrough"] as $passthroughMethod => $passthroughPath) {
+            $passthroughPath = rtrim($passthroughPath, "/");
+            if (!!preg_match("@^{$passthroughPath}(/.*)?$@", $uri) && ($passthroughMethod === $method || is_numeric($passthroughMethod))) {
+                return false;
+            }
+        }
+        /* Otherwise check if method (or lack of) and path matches and we should authenticate. */
+        foreach ((array) $this->options["path"] as $pathMethod => $pathPath) {
+            $pathPath = rtrim($pathPath, "/");
+            if (!!preg_match("@^{$pathPath}(/.*)?$@", $uri) && ($pathMethod === $method || is_numeric($pathMethod))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
I know the JWT it's like a password and should not be appears in the URL but I think it is kind of useful in some situations like when using proxy servers or when testing 