### PR TITLE
Pass back raw token in addition to decoded to success callback

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -128,7 +128,7 @@ class JwtAuthentication
 
         /* If callback returns false return with 401 Unauthorized. */
         if (is_callable($this->options["callback"])) {
-            $params = ["decoded" => $decoded];
+            $params = ["decoded" => $decoded, "token" => $token];
             if (false === $this->options["callback"]($request, $response, $params)) {
                 return $this->error($request, $response, [
                     "message" => $this->message ? $this->message : "Callback returned false"


### PR DESCRIPTION
When a callback occurs on success you only get "decode" back, sometimes you need "token" eg. for building an ajax request so you can add the bearer header.