### PR TITLE
Callable secret to support Firebase that has multiple kid's

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -254,7 +254,7 @@ final class JwtAuthentication implements MiddlewareInterface
         try {
             $decoded = JWT::decode(
                 $token,
-                $this->options["secret"],
+                is_callable($this->options["secret"]) ? $this->options["secret"]($token) : $this->options["secret"],
                 (array) $this->options["algorithm"]
             );
             return (array) $decoded;
@@ -327,7 +327,7 @@ final class JwtAuthentication implements MiddlewareInterface
     /**
      * Set the secret key.
      */
-    private function secret(string $secret): void
+    private function secret($secret): void
     {
         $this->options["secret"] = $secret;
     }


### PR DESCRIPTION
Firebase JWT tokens can have (currently) 3 `kid`'s in their headers and to validate the token you have to use the correct key. This PR allows the secret to be a callable function so you can grab the kid from the token and return it. For example:

```php
$authenticationOptions = [
    'secret'    => function ($token) {
        try {
            $jwt = (new Parser())->parse($token);
        } catch (\Exception $ex) {
            return null;
        }

        if (!$jwt->hasHeader('kid')) {
            return null;
        }

        $keyId = $jwt->getHeader('kid');

        return self::$keyStore->get($keyId);
    },
    'algorithm' => ['RS256'],
];
$app->add(new JwtAuthentication($authenticationOptions));
```

More info at https://firebase.google.com/docs/auth/admin/verify-id-tokens