### PR TITLE
php version fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.3",
         "psr/log": "^1.0",
         "firebase/php-jwt": "^3.0 || ^4.0 || ^5.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
It seems like you are using 7.2 features:
`Return value of Tuupola\\Middleware\\JwtAuthentication::secure() must be an instance of Tuupola\\Middleware\\void, none returned`

and 7.3 features:
https://github.com/tuupola/slim-jwt-auth/blob/3.x/src/JwtAuthentication.php line 126
https://github.com/php/php-src/commit/0aed2cc2a440e7be17552cc669d71fdd24d1204a

this fix would prevent users from getting a version, that produces errors on 7.1 which are obfuscated by logic form 7.3