### PR TITLE
Allow secret to be also an array

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -343,7 +343,7 @@ final class JwtAuthentication implements MiddlewareInterface
     /**
      * Set the secret key.
      */
-    private function secret(string $secret): void
+    private function secret($secret): void
     {
         $this->options["secret"] = $secret;
     }


### PR DESCRIPTION
Remove type hint for `string` in the `secret()` method as firebase/php-jwt allows an array of secrets for decoding the token:

https://github.com/firebase/php-jwt/blob/master/src/JWT.php#L99

I need it as I want to provide an array of secrets provided by a JKWS file. firebase/php-jwt will then automatically choose the right one out of the given ones.