### PR TITLE
Add request object to callback for errors

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -141,7 +141,7 @@ final class JwtAuthentication implements MiddlewareInterface
             $decoded = $this->decodeToken($token);
         } catch (RuntimeException | DomainException $exception) {
             $response = (new ResponseFactory)->createResponse(401);
-            return $this->processError($response, [
+            return $this->processError($request, $response, [
                 "message" => $exception->getMessage()
             ]);
         }
@@ -155,7 +155,6 @@ final class JwtAuthentication implements MiddlewareInterface
 
         /* Modify $request before calling next middleware. */
         if (is_callable($this->options["before"])) {
-            $response = (new ResponseFactory)->createResponse(200);
             $beforeRequest = $this->options["before"]($request, $params);
             if ($beforeRequest instanceof ServerRequestInterface) {
                 $request = $beforeRequest;
@@ -220,10 +219,13 @@ final class JwtAuthentication implements MiddlewareInterface
     /**
      * Call the error handler if it exists.
      */
-    private function processError(ResponseInterface $response, array $arguments): ResponseInterface
-    {
+    private function processError(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $arguments
+    ): ResponseInterface {
         if (is_callable($this->options["error"])) {
-            $handlerResponse = $this->options["error"]($response, $arguments);
+            $handlerResponse = $this->options["error"]($request, $response, $arguments);
             if ($handlerResponse instanceof ResponseInterface) {
                 return $handlerResponse;
             }

--- a/tests/JwtAuthenticationTest.php
+++ b/tests/JwtAuthenticationTest.php
@@ -533,7 +533,11 @@ class JwtAuthenticationTest extends TestCase
         $collection = new MiddlewareCollection([
             new JwtAuthentication([
                 "secret" => "supersecretkeyyoushouldnotcommit",
-                "error" => function (ResponseInterface $response, $arguments) use (&$dummy) {
+                "error" => function (
+                    ServerRequestInterface $request,
+                    ResponseInterface $response,
+                    $arguments
+                ) use (&$dummy) {
                     $dummy = true;
                 }
             ])
@@ -562,7 +566,11 @@ class JwtAuthenticationTest extends TestCase
         $collection = new MiddlewareCollection([
             new JwtAuthentication([
                 "secret" => "supersecretkeyyoushouldnotcommittogithub",
-                "error" => function (ResponseInterface $response, $arguments) use (&$dummy) {
+                "error" => function (
+                    ServerRequestInterface $request,
+                    ResponseInterface $response,
+                    $arguments
+                ) use (&$dummy) {
                     $dummy = true;
                     $response->getBody()->write("Error");
                     return $response;


### PR DESCRIPTION
Sometimes it's useful or required to have information of the request available to form a proper response. 

For example the `Accept` header of the request is required to decide in which format the response should be generated.

This would be a BC break. So maybe not for 3.x but for 4.x...

If we want to omit a BC we can just change the order of the args for the error callback and append the request to the end of the arguments. That way existing closures/callbacks would still work.