### PR TITLE
Pass request uri as an argument to error handler (see #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,16 @@ All notable changes to this project will be documented in this file, in reverse 
       "error" => [SomeErrorHandler::class, "error"]
   ]);
   ```
-
+### Added
+- The `error` handler now receives the request uri in the `$arguments` array. This is a workaround for [#96](https://github.com/tuupola/slim-jwt-auth/issues/96) which will be fixed in `4.x`.
+  ```php
+  $middleware = new JwtAuthentication([
+      "secret" => "supersecretkeyyoushouldnotcommit",
+      "error" => function ($response, $arguments) {
+          print_r(arguments["uri"]);
+      }
+  ]);
+  ```
 
 ## [3.2.0](https://github.com/tuupola/slim-jwt-auth/compare/3.1.1...3.2.0) - 2019-01-26
 

--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -141,7 +141,8 @@ final class JwtAuthentication implements MiddlewareInterface
         } catch (RuntimeException | DomainException $exception) {
             $response = (new ResponseFactory)->createResponse(401);
             return $this->processError($response, [
-                "message" => $exception->getMessage()
+                "message" => $exception->getMessage(),
+                "uri" => (string)$request->getUri()
             ]);
         }
 

--- a/tests/JwtAuthenticationTest.php
+++ b/tests/JwtAuthenticationTest.php
@@ -852,4 +852,33 @@ class JwtAuthenticationTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Success", $response->getBody());
     }
+
+    public function testShouldHaveUriInErrorHandlerIssue96()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/api/foo?bar=pop");
+
+        $dummy = null;
+
+        $default = function (ServerRequestInterface $request) {
+            $response = (new ResponseFactory)->createResponse();
+            $response->getBody()->write("Success");
+            return $response;
+        };
+
+        $collection = new MiddlewareCollection([
+            new JwtAuthentication([
+                "secret" => "supersecretkeyyoushouldnotcommit",
+                "error" => function (ResponseInterface $response, $arguments) use (&$dummy) {
+                    $dummy = $arguments["uri"];
+                }
+            ])
+        ]);
+
+        $response = $collection->dispatch($request, $default);
+
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals("", $response->getBody());
+        $this->assertEquals("https://example.com/api/foo?bar=pop", $dummy);
+    }
 }


### PR DESCRIPTION
This is a workaround because changing the error handler signature would
break BC. Removing the request in 3.x was an oversight on my part and
it will most likely be put back in 4.x.