### PR TITLE
Before & After callbacks also receive raw token

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ $app->add(new Tuupola\Middleware\JwtAuthentication([
 
 ### Before
 
-Before funcion is called only when authentication succeeds but before the next incoming middleware is called. You can use this to alter the request before passing it to the next incoming middleware in the stack. If it returns anything else than `Psr\Http\Message\ServerRequestInterface` the return value will be ignored.
+Before function is called only when authentication succeeds but before the next incoming middleware is called. You can use this to alter the request before passing it to the next incoming middleware in the stack. If it returns anything else than `Psr\Http\Message\ServerRequestInterface` the return value will be ignored.
 
 ``` php
 $app = new Slim\App;
@@ -207,6 +207,8 @@ $app->add(new Tuupola\Middleware\JwtAuthentication([
     }
 ]));
 ```
+
+> Note that both the after and before callback functions receive the raw token string as well as the decoded claims through the `$arguments` argument.
 
 ### Error
 

--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -146,7 +146,10 @@ final class JwtAuthentication implements MiddlewareInterface
             ]);
         }
 
-        $params = ["decoded" => $decoded];
+        $params = [
+            "decoded" => $decoded,
+            "token" => $token,
+        ];
 
         /* Add decoded token to request as attribute when requested. */
         if ($this->options["attribute"]) {


### PR DESCRIPTION
## What has been changed
Callbacks `after` and `before` receive both the decoded claims and the raw token string, as opposed to only receiving the decoded claims.

## The motivation
I needed to process/use the raw token further and the middleware does not offer any way to provide, as `fetchToken`'s visibility is _private_ and extension is not allowed.

I am forced to copy the very same code that fetches the token without this change.

## Compatibility
Backward & forward compatible, non-breaking change.

## Thanks
It would be awesome if this simple change could be swiftly integrated. Thank you in advance. 🥇 

## Implementation & Tests

1. I named the raw token argument as `raw`, I was also considering `encoded`, if you prefer the latter, let me know, I'll quickly update the PR.
2. I updated the test method `testShouldCallAfter` to also test for the added argument being passed correctly. Then I copied the code and created almost exacly the same test, only for the `before` callback - `testShouldCallBeforeWithProperArguments`. I copied the method for sake of more atomic tests. Though I'm not really fond of copying, so if you are like me, I can create a more convoluted test named for example `testShouldCallBeforeAndAfterWithProperArguments` that would test both cases.

Let me know what you think & thank you for cooperation and this nice middleware.