### PR TITLE
try to check cookie with `regexp`

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -254,6 +254,9 @@ final class JwtAuthentication implements MiddlewareInterface
 
         if (isset($cookieParams[$this->options["cookie"]])) {
             $this->log(LogLevel::DEBUG, "Using token from cookie");
+            if (preg_match($this->options["regexp"], $cookieParams[$this->options["cookie"]], $matches)) {
+                return $matches[1];
+            }
             return $cookieParams[$this->options["cookie"]];
         };
 


### PR DESCRIPTION
This small change will add `regexp` functionality also to cookie. 

It will be helpful for `@nuxtjs/auth` users, because it stores cookie with `Bearer ` word by default.