### PR TITLE
Allow 'ArrayAccess' objects as secret.

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -345,7 +345,7 @@ final class JwtAuthentication implements MiddlewareInterface
      */
     private function secret($secret): void
     {
-        if (false === is_array($secret) && false === is_string($secret)) {
+        if (false === is_array($secret) && false === is_string($secret) && ! $secret instanceof \ArrayAccess) {
             throw new InvalidArgumentException(
                 'Secret must be either a string or an array of "kid" => "secret" pairs'
             );

--- a/tests/ArrayAccessImpl.php
+++ b/tests/ArrayAccessImpl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tuupola\Middleware;
+
+class ArrayAccessImpl implements \ArrayAccess
+{
+    private $array = [];
+
+    public function offsetExists($offset)
+    {
+        return isset($this->array[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->array[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+}

--- a/tests/JwtAuthenticationTest.php
+++ b/tests/JwtAuthenticationTest.php
@@ -225,6 +225,60 @@ class JwtAuthenticationTest extends TestCase
         $this->assertEquals("", $response->getBody());
     }
 
+    public function testShouldReturn200WithSecretArrayAccess()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/api")
+            ->withHeader("Authorization", "Bearer " . self::$betaToken);
+
+        $default = function (ServerRequestInterface $request) {
+            $response = (new ResponseFactory)->createResponse();
+            $response->getBody()->write("Success");
+            return $response;
+        };
+
+        $secret = new ArrayAccessImpl();
+        $secret["acme"] = "supersecretkeyyoushouldnotcommittogithub";
+        $secret["beta"] ="anothersecretkeyfornevertocommittogithub";
+
+        $collection = new MiddlewareCollection([
+            new JwtAuthentication([
+                "secret" => $secret
+            ])
+        ]);
+
+        $response = $collection->dispatch($request, $default);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("Success", $response->getBody());
+    }
+
+    public function testShouldReturn401WithSecretArrayAccess()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/api")
+            ->withHeader("Authorization", "Bearer " . self::$betaToken);
+
+        $default = function (ServerRequestInterface $request) {
+            $response = (new ResponseFactory)->createResponse();
+            $response->getBody()->write("Success");
+            return $response;
+        };
+
+        $secret = new ArrayAccessImpl();
+        $secret["xxxx"] = "supersecretkeyyoushouldnotcommittogithub";
+        $secret["yyyy"] = "anothersecretkeyfornevertocommittogithub";
+
+        $collection = new MiddlewareCollection([
+            new JwtAuthentication([
+                "secret" => $secret
+            ])
+        ]);
+
+        $response = $collection->dispatch($request, $default);
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals("", $response->getBody());
+    }
+
     public function testShouldAlterResponseWithAnonymousAfter()
     {
         $request = (new ServerRequestFactory)


### PR DESCRIPTION
The underlying JWT library can use ArrayAccess objects as
secrets. This patch relaxes the input validation so it is possible to
use this feature.