### PR TITLE
Configurable response factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ $app->add(new Tuupola\Middleware\JwtAuthentication([
 ]));
 ```
 
+### Response Factory
+
+A custom PSR-17 compatible response factory can be provided. If none is provided, PSR-17 implementation auto-discovery is used. Response factory is used to create a new 401 response.
+
+```php
+$app = new Slim\App;
+
+$app->add(new Tuupola\Middleware\JwtAuthentication([
+    "responseFactory" => new MyResponseFactory,
+]));
+```
+
 ### Rules
 
 The optional `rules` parameter allows you to pass in rules which define whether the request should be authenticated or not. A rule is a callable which receives the request as parameter. If any of the rules returns boolean `false` the request will not be authenticated.


### PR DESCRIPTION
## Background

This middleware uses `tuupola/http-factory` to create a new response in case an error occurs.
The new response is then passed to the `error` callback function.

The mentioned http factory detects one of several supported installed PSR-7 libraries and uses one to create the response. 


## The Issue

After installing a package that consequently installed it's own dependency (`zendframework/zend-diactoros` PSR-7 implementation), which is one of the supported PSR-7 implementations `tuupola/http-factory` will detect and use, my `error` callback caused error, because it was expecting a Slim response implementation (`Slim\Http\Response`), but got the Zend implementation (`Zend\Diactoros\Response`) instead.

While this was not a grave issue and was solved by using bare `Psr\Http\Message\ResponseInterface`, there is currently no way around it.


## The solution

This solution provides a way to pass custom response factory to the middleware, so that one needs not rely on the default `tuupola/http-factory`, but falls back to the default, if no custom one is provided.
