### PR TITLE
Force atleast tuupola/http-factory:1.0.2 (fixes #193)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "^1.0",
         "firebase/php-jwt": "^3.0|^4.0|^5.0",
         "psr/http-message": "^1.0",
-        "tuupola/http-factory": "^0.4.0|^1.0",
+        "tuupola/http-factory": "^0.4.0|^1.0.2",
         "tuupola/callable-handler": "^0.3.0|^0.4.0|^1.0",
         "psr/http-server-middleware": "^1.0"
     },


### PR DESCRIPTION
`tuupola/http-factory:1.0.1` had a broken provide statement in `composer.json` which triggers composer2 to uninstall `psr/http-factory`. This PR upgrades minimum requirement to `tuupola/http-factory:1.0.2`.